### PR TITLE
🐛bugfix: 修复低版本浏览器报错的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,13 @@ export default (api, opts) => {
   api.log.success("insert google analytics");
   const gaTpl = function(code) {
     return `
-    (function(){ 
+    (function(){
       var script = document.createElement('script');
       script.src = 'https://www.googletagmanager.com/gtag/js?id=${code}';
       script.async = true;
       script.onload = function() {
         window.dataLayer = window.dataLayer || [];
-        window.gtag = () => {
+        window.gtag = function() {
           window.dataLayer.push(arguments);
         };
         window.gtag('js', new Date());


### PR DESCRIPTION
字符串模板里面的arrow function 不会被编译的哈